### PR TITLE
Only truncate Wordpress server address on paste or change events

### DIFF
--- a/yasbil-extn/yasbil_ui_options.js
+++ b/yasbil-extn/yasbil_ui_options.js
@@ -14,8 +14,15 @@ $(document).ready(function()
     $('input[name=wp_app_pass]').val(settings.PASS);
 
     // remove trailing spaces and slashes from WP-url
-    $('input[name=wp_url]').on('change paste keyup', function() {
-        $(this).val($(this).val().trim().replace(/\/+$/g, ''));
+    $('input[name=wp_url]').on('paste change', function(event) {
+        if(event.type === 'paste') {
+            event.preventDefault();
+            var text = (event.originalEvent.clipboardData || window.clipboardData).getData('text');
+        } else {
+            var text = $(this).val();
+        }
+        const modifiedText = text.trim().replace(/\/+$/g, '');
+        $(this).val(modifiedText);
     });
 
     // remove trailing spaces from WP-user


### PR DESCRIPTION
Don't do it on keyup events because it prevents users from being able to enter any URL with a forward slash. 

Hey @nilavra . This should address the small side issue I'd pointed out in #17. Hope the change is acceptable. Happy to work with you to get in merged.

P.S. I also had some documentation on how to get the extension running locally for debugging using web-ext for development. Would such a commit with this documentation also be welcome? Or better if I just keep that in my own fork. Curious what your development set up/workflow for this extension is as well.